### PR TITLE
Fixed Content-Type of Message API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     compile 'com.github.bumptech.glide:glide:3.8.0'
     testCompile 'junit:junit:4.12'
     compile 'de.hdodenhof:circleimageview:2.1.0'
+    compile 'com.facebook.stetho:stetho:1.5.0'
+    compile 'com.facebook.stetho:stetho-okhttp3:1.5.0'
 
 }
 repositories {

--- a/app/src/main/java/com/tuvy/tomosugi/minimalpairs/MainActivity.kt
+++ b/app/src/main/java/com/tuvy/tomosugi/minimalpairs/MainActivity.kt
@@ -1,14 +1,14 @@
 package com.tuvy.tomosugi.minimalpairs
 
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import android.support.v4.view.ViewPager
+import android.support.v7.app.AppCompatActivity
 import android.util.Log
+import com.facebook.stetho.Stetho
 import com.tuvy.tomosugi.minimalpairs.controller.MainFragmentStatePagerAdapter
 import com.tuvy.tomosugi.minimalpairs.controller.MinimalPairsClient
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
-
 
 class MainActivity : AppCompatActivity() {
 
@@ -17,22 +17,24 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-//        メッセージ送信用API(テスト)
-//        client.post(1, 2, "hello")
-//                .subscribeOn(Schedulers.io())
-//                .observeOn(AndroidSchedulers.mainThread())
-//                .doOnSubscribe {
-//                    Log.d("post", "doOnSubscribe")
-//                }
-//                .doOnError {
-//                    Log.d("post", "doOnError")
-//                }
-//                .doOnNext {
-//                    Log.d("post", "doOnNext")
-//                }
-//                .subscribe {
-//                    Log.d("post", "subscribe")
-//                }
+        Stetho.initializeWithDefaults(this)
+
+        // メッセージ送信用API(テスト)
+        client.post(1, 2, "hello")
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .doOnSubscribe {
+                    Log.d("post", "doOnSubscribe")
+                }
+                .doOnError {
+                    Log.d("post", "doOnError")
+                }
+                .doOnNext {
+                    Log.d("post", "doOnNext")
+                }
+                .subscribe {
+                    Log.d("post", "subscribe")
+                }
 
 //        プロフィール取得用API(テスト)
 //        client.getProfile()

--- a/app/src/main/java/com/tuvy/tomosugi/minimalpairs/controller/MinimalPairsClient.kt
+++ b/app/src/main/java/com/tuvy/tomosugi/minimalpairs/controller/MinimalPairsClient.kt
@@ -1,10 +1,14 @@
 package com.tuvy.tomosugi.minimalpairs.controller
 
 import android.util.Log
+import com.facebook.stetho.okhttp3.StethoInterceptor
 import com.tuvy.tomosugi.minimalpairs.model.HistoryMessage
-import com.tuvy.tomosugi.minimalpairs.model.Message
 import com.tuvy.tomosugi.minimalpairs.model.Status
 import com.tuvy.tomosugi.minimalpairs.model.User
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
@@ -17,9 +21,13 @@ import retrofit2.http.*
 class MinimalPairsClient {
 
     private val endpoint: String = "https://guarded-garden-55846.herokuapp.com/api/"
+    private val okHttpClient = OkHttpClient.Builder()
+            .addNetworkInterceptor(StethoInterceptor())
+            .build()
 
     fun history(userId: Int, partnerId: Int): io.reactivex.Observable<HistoryMessage> {
         val retrofit = Retrofit.Builder()
+                .client(okHttpClient)
                 .baseUrl(endpoint)
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                 .addConverterFactory(GsonConverterFactory.create())
@@ -32,18 +40,24 @@ class MinimalPairsClient {
     fun post(userId: Int, partnerId: Int, text: String): io.reactivex.Observable<Status> {
         Log.d("Client.post", "check")
         val retrofit = Retrofit.Builder()
+                .client(okHttpClient)
                 .baseUrl(endpoint)
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                 .addConverterFactory(GsonConverterFactory.create())
                 .build()
         Log.d("Client.post", "retrofit build ok")
 
+        val userIdPart = MultipartBody.create(MediaType.parse("text/plain"), userId.toString())
+        val partnerIdPart = MultipartBody.create(MediaType.parse("text/plain"), partnerId.toString())
+        val textPart = MultipartBody.create(MediaType.parse("text/plain"), text)
+
         val api = retrofit.create(MinimalPairsApi::class.java)
-        return api.post(userId = userId, partnerId = partnerId, text = text)
+        return api.post(userId = userIdPart, partnerId = partnerIdPart, text = textPart)
     }
 
     fun getProfile(): io.reactivex.Observable<User> {
         val retrofit = Retrofit.Builder()
+                .client(okHttpClient)
                 .baseUrl(endpoint)
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                 .addConverterFactory(GsonConverterFactory.create())
@@ -61,12 +75,12 @@ class MinimalPairsClient {
                 @Query("partner_id") partnerId: Int
         ): io.reactivex.Observable<HistoryMessage>
 
-        @FormUrlEncoded
+        @Multipart
         @POST("message/create")
         fun post(
-                @Field("user_id") userId: Int,
-                @Field("partner_id") partnerId: Int,
-                @Field("content") text: String
+                @Part("user_id") userId: RequestBody,
+                @Part("partner_id") partnerId: RequestBody,
+                @Part("content") text: RequestBody
         ): io.reactivex.Observable<Status>
 
         @GET("user/1")


### PR DESCRIPTION
フォームでデータを送信する場合は以下の2種類の方法があって、
1. Content-Type=application/x-www-form-urlencoded
2. Content-Type=multipart/form-data

サーバー的には方法2で受け取っているんだけど、Androidからは方法1でパラメータを送信していたのが原因で、方法2でリクエストを投げるように変更